### PR TITLE
Add token positions to GSII model, and add fine tuning model by passing T5 model to trainer

### DIFF
--- a/amrlib/models/parse_gsii/modules/parser.py
+++ b/amrlib/models/parse_gsii/modules/parser.py
@@ -88,7 +88,7 @@ class Parser(nn.Module):
                         'local_idx2token':data['local_idx2token'],
                         'copy_seq':data['copy_seq']}
             init_state_dict = {}
-            init_hyp = Hypothesis(init_state_dict, [DUM], 0.)
+            init_hyp = Hypothesis(init_state_dict, [DUM], 0., [-1])
             bsz = word_repr.size(1)
             beams = [ Beam(beam_size, min_time_step, max_time_step, [init_hyp]) for i in range(bsz)]
             search_by_batch(self, beams, mem_dict)
@@ -160,7 +160,7 @@ class Parser(nn.Module):
         for s, t, local_vocab in zip(topk_scores.tolist(), topk_token.tolist(), local_vocabs):
             res = []
             for score, token in zip(s, t):
-                res.append((idx2token(token, local_vocab), score))
+                res.append((idx2token(token, local_vocab), score, token))
             results.append(res)
 
         return new_state_dict, results

--- a/amrlib/models/parse_t5/trainer.py
+++ b/amrlib/models/parse_t5/trainer.py
@@ -45,7 +45,7 @@ class T2TDataCollator:
 # Note that for save_steps, steps means gradient updates (not batch) so if
 # gradient_accumulation_steps=4 and save_steps=1000, then checkpoint is saved every 4000 batches.
 class Trainer(object):
-    def __init__(self, args):
+    def __init__(self, args, model: T5ForConditionalGeneration = None):
         # General arguments
         self.gen_args           = args['gen_args']
         self.model_name_or_path = self.gen_args['model_name_or_path']
@@ -57,6 +57,7 @@ class Trainer(object):
         # HuggingFace trainer arguments
         # See https://github.com/huggingface/transformers/blob/master/src/transformers/training_args.py
         self.training_args = TrainingArguments(**args['hf_args'])
+        self.model = model
         set_seed(self.training_args.seed)
 
     def train(self):
@@ -65,7 +66,8 @@ class Trainer(object):
         # Load pretrained model and tokenizer
         print('Loading model and tokenizer')
         self.tokenizer = T5Tokenizer.from_pretrained(self.model_name_or_path)
-        self.model     = T5ForConditionalGeneration.from_pretrained(self.model_name_or_path)
+        if self.model is None:
+            self.model     = T5ForConditionalGeneration.from_pretrained(self.model_name_or_path)
         # Clear out the "task_specific_params" and add this one
         self.model.config.task_specific_params = {'translation_amr_to_text':self.gen_args}
         # Load the datasets


### PR DESCRIPTION
This pull request has two contributions:

* Add token position to GSII model: this optionally adds relations to nodes of where the corresponding word appears in the source sentence as a 0-index document based offset.  This is nice when you want to, say for example, add additional linguistic tokens to the graph such as POS or named entities.
* Provides a way to add a trained model to the T5 trainer to treat the existing pre-trained models as a check point, then continue to train it on other (i.e. domain specific) corpora.