### PR TITLE
Add remove_unused_columns to hf_args

### DIFF
--- a/configs/model_generate_t5.json
+++ b/configs/model_generate_t5.json
@@ -15,6 +15,7 @@
         "do_eval"                       : false,
         "overwrite_output_dir"          : false,
         "prediction_loss_only"          : true,
+        "remove_unused_columns"         : false,
         "num_train_epochs"              : 8,
         "save_steps"                    : 1000,
         "save_total_limit"              : 2,

--- a/configs/model_generate_t5wtense.json
+++ b/configs/model_generate_t5wtense.json
@@ -15,6 +15,7 @@
         "do_eval"                       : false,
         "overwrite_output_dir"          : false,
         "prediction_loss_only"          : true,
+        "remove_unused_columns"         : false,
         "num_train_epochs"              : 6,
         "save_steps"                    : 4534,
         "save_total_limit"              : 2,


### PR DESCRIPTION
With recent versions of transformers, all unused transformer trainer arguments are deleted. This causes issues in the training process where "target_ids" and "decoder_attention_mask" variables were being deleted even though they were being used in this code. Works with transformers 4.36.2